### PR TITLE
updated README with important instructions for vagrant dev box setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Supervisor and Nginx are setup to run automatically, but you will have to run th
     cd /vagrant
     sudo su - postgres -c 'psql -c "ALTER USER yoda WITH SUPERUSER;"'
     sudo ./setup.py develop
+    sudo ./manage.py migrate
     sudo chmod -R g+wx-s /usr/local /srv
     sudo chmod -R a+r /usr/local
 


### PR DESCRIPTION
By default, yoda is not a superuser, so a command must be executed
  to make yoda a superuser.
