### PR TITLE
handle AmbiguousTimeError so that it doesn't crash server

### DIFF
--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -748,11 +748,22 @@ class Resource(object):
                 return cls.create_single(data, request)
 
     @classmethod
-    def create_single(cls, data, request):
+    def create_resource(cls, data, request):
         obj_params = request.GET.dict()
         new_resource = cls(data=data, request=request, filters=obj_params)
+        new_resource.save()
+        response_data = new_resource.serialize()
+        tags = new_resource.get_tags()
+        if tags:
+            stream_data = json.dumps(new_resource.serialize_stream())
+        for tag in tags:
+            zmq_socket.send_string(tag + ' ' + stream_data)
+        return response_data
+
+    @classmethod
+    def create_single(cls, data, request):
         try:
-            new_resource.save()
+            response_data = cls.create_resource(data, request)
         except IntegrityError:
             return render_error(
                 400, 'Error storing object. Either required fields are '
@@ -762,34 +773,23 @@ class Resource(object):
             return render_error(
                 400, 'Error storing object. Timestamp is ambiguous',
                 request)
-        response_data = new_resource.serialize()
-        tags = new_resource.get_tags()
-        if tags:
-            stream_data = json.dumps(new_resource.serialize_stream())
-        for tag in tags:
-            zmq_socket.send_string(tag + ' ' + stream_data)
         return cls.render_response(response_data, request,
                                    status=HTTP_STATUS_CREATED)
-
     @classmethod
     def create_list(cls, data, request):
         response_data = []
         for item in data:
-            obj_params = request.GET.dict()
-            new_resource = cls(data=item, request=request, filters=obj_params)
             try:
-                new_resource.save()
+                response_data.append(cls.create_resource(item, request))
             except IntegrityError:
                 return render_error(
                     400, 'Error storing object. Either required fields are '
                     'missing data or a matching object already exists',
                     request)
-            response_data.append(new_resource.serialize())
-            tags = new_resource.get_tags()
-            if tags:
-                stream_data = json.dumps(new_resource.serialize_stream())
-            for tag in tags:
-                zmq_socket.send_string(tag + ' ' + stream_data)
+            except AmbiguousTimeError:
+                return render_error(
+                    400, 'Error storing object. Timestamp is ambiguous',
+                    request)
         return cls.render_response(response_data, request,
                                    status=HTTP_STATUS_CREATED)
 

--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -17,7 +17,7 @@ from chain.settings import WEBSOCKET_PATH, WEBSOCKET_HOST, \
     ZMQ_PASSTHROUGH_URL_PULL
 import zmq
 import re
-
+from pytz import AmbiguousTimeError
 
 def capitalize(word):
     return word[0].upper() + word[1:]
@@ -757,6 +757,10 @@ class Resource(object):
             return render_error(
                 400, 'Error storing object. Either required fields are '
                 'missing data or a matching object already exists',
+                request)
+        except AmbiguousTimeError:
+            return render_error(
+                400, 'Error storing object. Timestamp is ambiguous',
                 request)
         response_data = new_resource.serialize()
         tags = new_resource.get_tags()

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -809,7 +809,6 @@ class SiteResource(Resource):
             },
             'devices': []
         }
-        sensor_hash = {}
         for device in devices:
             dev_resource = DeviceResource(obj=device, request=request)
             dev_data = dev_resource.serialize(rels=False)
@@ -824,13 +823,6 @@ class SiteResource(Resource):
                 sensor_data['href'] = sensor_resource.get_single_href()
                 dev_data['sensors'].append(sensor_data)
                 sensor_data['data'] = []
-                sensor_hash[sensor.id] = sensor_data
-
-        #import pdb; pdb.set_trace()
-        for data in db_sensor_data:
-            data_data = ScalarSensorDataResource(
-                obj=data, request=request).serialize(rels=False)
-            sensor_hash[data.sensor_id]['data'].append(data_data)
         return cls.render_response(response, request)
 
     @classmethod

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -793,15 +793,12 @@ class SiteResource(Resource):
 
     @classmethod
     def site_summary_view(cls, request, id):
-        time_begin = timezone.now() - timedelta(hours=2)
         #filters = request.GET.dict()
         devices = Device.objects.filter(site_id=id).select_related(
             'sensors',
             'sensors__metric',
             'sensors__unit'
         )
-        db_sensor_data = ScalarData.objects.filter(sensor__device__site_id=id,
-                                                   timestamp__gt=time_begin)
         response = {
             '_links': {
                 'self': {'href': full_reverse('site-summary', request,

--- a/chain/core/tests.py
+++ b/chain/core/tests.py
@@ -591,11 +591,11 @@ class ApiSitesTests(ChainTestCase):
         summary_dev = summary.devices[0]
         self.assertIn('metric', summary_dev['sensors'][0])
 
-    def test_site_summary_should_have_data(self):
+    def test_site_summary_should_have_empty_data(self):
         site = self.get_a_site()
         summary = self.get_resource(site.links['ch:siteSummary'].href)
         summary_dev = summary.devices[0]
-        self.assertIn('value', summary_dev['sensors'][0]['data'][0])
+        self.assertEqual(0, len(summary_dev['sensors'][0]['data']))
 
     def test_site_summary_resources_should_have_href(self):
         site = self.get_a_site()

--- a/chain/core/tests.py
+++ b/chain/core/tests.py
@@ -361,7 +361,7 @@ class SafePostTests(ChainTestCase):
         mime_type = 'application/hal+json'
         accept_header = mime_type + ',' + ACCEPT_TAIL
         try:
-            response = self.client.post(data_url, 
+            response = self.client.post(data_url,
                                         json.dumps(data),
                                         content_type=mime_type,
                                         HTTP_ACCEPT=accept_header,
@@ -369,6 +369,7 @@ class SafePostTests(ChainTestCase):
         except AmbiguousTimeError:
             self.assertTrue(False)
         self.assertEqual(response.status_code, HTTP_STATUS_BAD_REQUEST)
+        self.assertEqual(response['Content-Type'], "application/json")
 
 class ApiRootTests(ChainTestCase):
 


### PR DESCRIPTION
fixes #62 

Also refactored create_single and create_list in api. They are now wrapper functions that call create_resource, which saves and serializes the data.