### PR TITLE
change jquery-ui URI to protocol-relative URL

### DIFF
--- a/chain/core/templates/resource.html
+++ b/chain/core/templates/resource.html
@@ -10,7 +10,7 @@
     <link href="/static/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <!-- RickShaw -->
     <link rel="stylesheet" href="/static/lib/rickshaw.min.css">
-    <link type="text/css" rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
+    <link type="text/css" rel="stylesheet" href="//code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css">
     <style>
         .rickshaw_graph .detail .x_label {
             top: -10px;  /* workaround so hovers don't overlap when the point


### PR DESCRIPTION
Chain's web template contains a hard-coded HTTP URL to jquery-ui via CDN.  This fails to load when accessing Chain via HTTPS.  The attached PR changes this to protocol-relative URL so that jquery-ui will be loaded using the same protocol as the referencing page.  Alternatively, this could just be changed to an HTTPS URL.