### PR TITLE
remove ScalarDataModel

### DIFF
--- a/chain/core/admin.py
+++ b/chain/core/admin.py
@@ -1,13 +1,12 @@
 from django.contrib import admin
 from chain.core.models import (Site, Device, Unit, Metric, ScalarSensor,
-                                 ScalarData, Person, GeoLocation,
+                                 Person, GeoLocation,
                                  PresenceData, PresenceSensor)
 
 
 admin.site.register(GeoLocation)
 admin.site.register(Site)
 admin.site.register(Device)
-admin.site.register(ScalarData)
 admin.site.register(ScalarSensor)
 admin.site.register(Unit)
 admin.site.register(Metric)

--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -426,7 +426,6 @@ class Resource(object):
                 self._data = self.serialize_single(embed, cache,
                                                    *args, **kwargs)
                 cache[(self._obj.__class__, self._obj.id, embed)] = self._data
-
         return self._data
 
     def stub_object_finding(self, obj, field_name, field_value):

--- a/chain/core/models.py
+++ b/chain/core/models.py
@@ -97,25 +97,25 @@ class ScalarSensor(models.Model):
         return self.metric.name
 
 
-#class ScalarData(models.Model):
-#    '''A data point representing scalar sensor data, such as temperature,
-#    humidity, etc.'''
-#    # Django automatically creates indices on foreign keys
-#    sensor = models.ForeignKey(ScalarSensor, related_name='scalar_data')
-#    timestamp = models.DateTimeField(default=timezone.now, blank=True,
-#                                     db_index=True)
-#    value = models.FloatField()
-#
-#    class Meta:
-#        verbose_name_plural = "scalar data"
-#        index_together = [['sensor', 'timestamp']]
-#
-#    def __repr__(self):
-#        return 'ScalarData(timestamp=%r, value=%r, sensor=%r)' % (
-#            self.timestamp, self.value, self.sensor)
-#
-#    def __str__(self):
-#        return '%.3f %s' % (self.value, self.sensor.unit)
+class ScalarData(models.Model):
+    '''A data point representing scalar sensor data, such as temperature,
+    humidity, etc.'''
+    # Django automatically creates indices on foreign keys
+    sensor = models.ForeignKey(ScalarSensor, related_name='scalar_data')
+    timestamp = models.DateTimeField(default=timezone.now, blank=True,
+                                     db_index=True)
+    value = models.FloatField()
+
+    class Meta:
+        verbose_name_plural = "scalar data"
+        index_together = [['sensor', 'timestamp']]
+
+    def __repr__(self):
+        return 'ScalarData(timestamp=%r, value=%r, sensor=%r)' % (
+            self.timestamp, self.value, self.sensor)
+
+    def __str__(self):
+        return '%.3f %s' % (self.value, self.sensor.unit)
 
 
 class Person(models.Model):

--- a/chain/core/models.py
+++ b/chain/core/models.py
@@ -97,25 +97,25 @@ class ScalarSensor(models.Model):
         return self.metric.name
 
 
-class ScalarData(models.Model):
-    '''A data point representing scalar sensor data, such as temperature,
-    humidity, etc.'''
-    # Django automatically creates indices on foreign keys
-    sensor = models.ForeignKey(ScalarSensor, related_name='scalar_data')
-    timestamp = models.DateTimeField(default=timezone.now, blank=True,
-                                     db_index=True)
-    value = models.FloatField()
-
-    class Meta:
-        verbose_name_plural = "scalar data"
-        index_together = [['sensor', 'timestamp']]
-
-    def __repr__(self):
-        return 'ScalarData(timestamp=%r, value=%r, sensor=%r)' % (
-            self.timestamp, self.value, self.sensor)
-
-    def __str__(self):
-        return '%.3f %s' % (self.value, self.sensor.unit)
+#class ScalarData(models.Model):
+#    '''A data point representing scalar sensor data, such as temperature,
+#    humidity, etc.'''
+#    # Django automatically creates indices on foreign keys
+#    sensor = models.ForeignKey(ScalarSensor, related_name='scalar_data')
+#    timestamp = models.DateTimeField(default=timezone.now, blank=True,
+#                                     db_index=True)
+#    value = models.FloatField()
+#
+#    class Meta:
+#        verbose_name_plural = "scalar data"
+#        index_together = [['sensor', 'timestamp']]
+#
+#    def __repr__(self):
+#        return 'ScalarData(timestamp=%r, value=%r, sensor=%r)' % (
+#            self.timestamp, self.value, self.sensor)
+#
+#    def __str__(self):
+#        return '%.3f %s' % (self.value, self.sensor.unit)
 
 
 class Person(models.Model):

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -22,19 +22,17 @@ class ScalarSensorDataResource(Resource):
     resource_type = 'scalar_data'
     model_fields = ['timestamp', 'value']
     required_fields = ['value']
-    # set queryset to True because list_view expects queryset
-    queryset = True
     default_timespan = timedelta(hours=6)
 
     def __init__(self, *args, **kwargs):
         super(ScalarSensorDataResource, self).__init__(*args, **kwargs)
-        if self._data:
+        if self._state == 'data':
             # deserialize data
             self.sensor_id = self._filters.get('sensor_id')
             self.value = self.sanitize_field_value('value', self._data.get('value'))
             self.timestamp = self.sanitize_field_value('timestamp', self._data.get('timestamp'))
             # treat sensor data like an object
-            self._schema = 'object'
+            self._state = 'object'
         if 'queryset' in kwargs:
             # we want to default to the last page, not the first page
             pass

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -33,7 +33,8 @@ class ScalarSensorDataResource(Resource):
             self.sensor_id = self._filters.get('sensor_id')
             self.value = self.sanitize_field_value('value', self._data.get('value'))
             self.timestamp = self.sanitize_field_value('timestamp', self._data.get('timestamp'))
-            self._data = self.serialize_single()
+            # treat raw sensor data like an object
+            self._schema = 'object'
         if 'queryset' in kwargs:
             # we want to default to the last page, not the first page
             pass
@@ -123,6 +124,9 @@ class ScalarSensorDataResource(Resource):
             'timestamp': obj['time']}
             for obj in objs]
         return serialized_data
+    
+    def get_cache_key(self):
+        return self.sensor_id, self.timestamp
 
     def format_time(self, timestamp):
         return calendar.timegm(timestamp.timetuple())
@@ -157,6 +161,10 @@ class ScalarSensorDataResource(Resource):
                 args=(self._filters['sensor_id'],))}
         }
         return data
+
+    def get_single_href(self):
+        return full_reverse(self.resource_name + '-single',
+                            self._request, args=(self.sensor_id,self.timestamp))
 
     def get_tags(self):
         if not self.sensor_id:

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -19,6 +19,7 @@ influx_client = InfluxClient(INFLUX_HOST, INFLUX_PORT, INFLUX_DATABASE, INFLUX_M
 #FIXME (might want to do this differently)
 id = count(1)
 
+#TODO: Move this somewhere else
 class AttrDict(dict):
 
     def __getattr__(self, key):
@@ -31,13 +32,14 @@ class AttrDict(dict):
         
 
 class ScalarSensorDataResource(Resource):
-    model = ScalarData
+    #model = ScalarData
     display_field = 'timestamp'
     resource_name = 'scalar_data'
     resource_type = 'scalar_data'
     model_fields = ['timestamp', 'value']
     required_fields = ['value']
-    queryset = ScalarData.objects
+    #FIXME
+    queryset = ScalarData.objects 
     default_timespan = timedelta(hours=6)
 
     def __init__(self, *args, **kwargs):

--- a/chain/core/resources.py
+++ b/chain/core/resources.py
@@ -2,7 +2,7 @@ from chain.core.api import Resource, ResourceField, CollectionField
 from chain.core.api import full_reverse
 from chain.core.api import CHAIN_CURIES
 from chain.core.api import BadRequestException
-from chain.core.api import register_resource, get_filtered_fields
+from chain.core.api import register_resource
 from chain.core.models import Site, Device, ScalarSensor, \
     PresenceSensor, PresenceData, Person
 from django.conf.urls import include, patterns, url
@@ -22,7 +22,7 @@ class ScalarSensorDataResource(Resource):
     resource_type = 'scalar_data'
     model_fields = ['timestamp', 'value']
     required_fields = ['value']
-    # set queryset to True for ScalarSensorDataResource so that serialize_list gets called
+    # set queryset to True because list_view expects queryset
     queryset = True
     default_timespan = timedelta(hours=6)
 
@@ -33,7 +33,7 @@ class ScalarSensorDataResource(Resource):
             self.sensor_id = self._filters.get('sensor_id')
             self.value = self.sanitize_field_value('value', self._data.get('value'))
             self.timestamp = self.sanitize_field_value('timestamp', self._data.get('timestamp'))
-            # treat raw sensor data like an object
+            # treat sensor data like an object
             self._schema = 'object'
         if 'queryset' in kwargs:
             # we want to default to the last page, not the first page

--- a/chain/core/tests.py
+++ b/chain/core/tests.py
@@ -45,7 +45,7 @@ class FakeZMQSocket(object):
 # anything that imports chain.api should come after this
 zmq.Context = FakeZMQContext
 
-from chain.core.models import ScalarData, Unit, Metric, Device, ScalarSensor, Site, \
+from chain.core.models import Unit, Metric, Device, ScalarSensor, Site, \
     PresenceSensor, Person
 from chain.core.models import GeoLocation
 from chain.core.resources import DeviceResource
@@ -187,7 +187,6 @@ class ChainTestCase(TestCase):
                 'value': 23.0})
         for data in self.scalar_data:
             resources.influx_client.post(data['sensor'].id, data['value'], data['timestamp'])
-            #data.save()
 
     def get_resource(self, url, mime_type='application/hal+json',
                      expect_status_code=HTTP_STATUS_SUCCESS,
@@ -292,10 +291,13 @@ class ChainTestCase(TestCase):
 class ScalarSensorDataTest(ChainTestCase):
 
     def test_data_can_be_added(self):
-        data = ScalarData(sensor=self.sensors[0], value=25)
-        data.save()
-        resources.influx_client.post(data.sensor_id, data.value, data.timestamp)
-        self.assertEqual(data.value, 25)
+        data = {
+            'sensor_id': self.sensors[0].id,
+            'value': 25,
+            'timestamp': now()
+        }
+        resources.influx_client.post(data['sensor_id'], data['value'], data['timestamp'])
+        self.assertEqual(data['value'], 25)
 
 
 class BasicHALJSONTests(ChainTestCase):

--- a/chain/influx_client.py
+++ b/chain/influx_client.py
@@ -46,6 +46,7 @@ class InfluxClient(object):
         return response
 
     def get(self, query, database=False):
+        # database arguement should be true for any sensor data queries
         if database:
             response = self.request('GET',
                                     self._url + '/query',
@@ -64,7 +65,12 @@ class InfluxClient(object):
                                                                                                     filters['sensor_id'],
                                                                                                     timestamp_gte,
                                                                                                     timestamp_lt)
+        result = self.get_values(self.get(query, True))
+        return result
 
+    def get_last_sensor_data(self, sensor_id):
+        query = "SELECT LAST(value) FROM {0} WHERE sensor_id = \'{1}\'".format(self._measurement,
+                                                                           sensor_id)
         result = self.get_values(self.get(query, True))
         return result
 


### PR DESCRIPTION
This removes ScalarDataModel so sensor data will no longer get pushed to postgres. Each ScalarSensorDataResource will have its value, timestamp, and sensor_id as instance variables. Also refactors self._queryset and self._obj in Resource.