### PR TITLE
batch sensor data queries when building summary

### DIFF
--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -191,7 +191,7 @@ class Resource(object):
     def get_object_by_id(cls, id):
         return cls.queryset.get(id=id)
 
-    def serialize_single(self, embed=True, cache=None, rels=True):
+    def serialize_single(self, embed=True, cache=None, rels=True, *args, **kwargs):
         '''Serializes this object, assuming that there is a single instance to
         be serialized. Note that this only gets called from the top-level
         serialize() method, which handles checking whether we're in the

--- a/chain/core/tests.py
+++ b/chain/core/tests.py
@@ -186,7 +186,11 @@ class ChainTestCase(TestCase):
                 'timestamp': now() - timedelta(minutes=1),
                 'value': 23.0})
         for data in self.scalar_data:
-            resources.influx_client.post(data['sensor'].id, data['value'], data['timestamp'])
+            resources.influx_client.post(data['sensor'].device.site.id,
+                                         data['sensor'].device.id,
+                                         data['sensor'].id,
+                                         data['value'],
+                                         data['timestamp'])
 
     def get_resource(self, url, mime_type='application/hal+json',
                      expect_status_code=HTTP_STATUS_SUCCESS,
@@ -292,11 +296,15 @@ class ScalarSensorDataTest(ChainTestCase):
 
     def test_data_can_be_added(self):
         data = {
-            'sensor_id': self.sensors[0].id,
+            'sensor': self.sensors[0],
             'value': 25,
             'timestamp': now()
         }
-        resources.influx_client.post(data['sensor_id'], data['value'], data['timestamp'])
+        resources.influx_client.post(data['sensor'].device.site.id,
+                                     data['sensor'].device.id,
+                                     data['sensor'].id,
+                                     data['value'],
+                                     data['timestamp'])
         self.assertEqual(data['value'], 25)
 
 
@@ -959,7 +967,7 @@ class ApiScalarSensorDataTests(ChainTestCase):
             sensor.links['ch:dataHistory'].href)
         self.assertIn('timestamp', sensor_data.data[0])
         self.assertIn('value', sensor_data.data[0])
-
+    
     def test_sensor_data_should_have_data_type(self):
         sensor = self.get_a_sensor()
         sensor_data = self.get_resource(


### PR DESCRIPTION
Fixes #75.

`ScalarSensorDataResource` now also holds `site_id` and `device_id`. When building site summary, one query is executed to grab last value for each sensor in the site.