### PR TITLE
Add title to self links on resources

### DIFF
--- a/chain/core/api.py
+++ b/chain/core/api.py
@@ -253,6 +253,15 @@ class Resource(object):
                 data['_links'][field_name] = collection.serialize(
                     self, self._request, cache)
 
+            title = self.display_field
+            if title in self.model_fields:
+                data['_links']['self']['title'] = self.serialize_field(
+                    getattr(self._obj, title))
+            elif title in self.stub_fields.keys():
+                stub_data = getattr(self._obj, title)
+                data['_links']['self']['title'] = getattr(stub_data,
+                    self.stub_fields[title])
+
         for field_name in self.model_fields:
             data[field_name] = self.serialize_field(
                 getattr(self._obj, field_name))


### PR DESCRIPTION
This pull request adds a `title` property to `self` links on resources, making the `self` link more equivalent to the way a link to a resource would appear from another resource.

Currently, when [chainclient.py](https://github.com/ssfrr/chainclient.py) creates a child resource, it adds the full resource to the `items` array on its cached copy, essentially making the newly created resource "embedded" on the cached copy, with no associated link.  This works for chainclient.py because when it iterates over a collection, it fetches each resource in full.  However, having some resources that are *only* embedded without a corresponding link precludes a client from iterating over just the *links* and determining whether each link should actually be fetched by first looking at its properties.  Furthermore, draft-kelly-json-hal-08 suggests in §8.3 that links SHOULD NOT entirely "swap out" links for embedded resources, which is the state that chainclient.py's cached object has now effectively ended up in.

Currently, the response to POSTing a createForm is insufficient to fully add a complete link to the newly created resource to its cached parent, as there is no way of knowing how the server would assign `title` (and potentially other properties) to the link.  The aim of this pull request is to include those properties in the `self` link, allowing the self link from the new resource to be added to a cached parent resource in a way that matches what would be received if the parent were re-requested in full following successful creation of the child.