### PR TITLE
remove sleep that unnecessarily ratelimits websocket data

### DIFF
--- a/chain/websocketd.py
+++ b/chain/websocketd.py
@@ -79,7 +79,6 @@ def close_socket(zmq_sock):
 def select_zmq_socks():
     logger.info("Starting select loop over ZMQ sockets")
     while True:
-        gevent.sleep(seconds=0.0625, ref=True)
         while len(zmq_socks) == 0:
             gevent.sleep(seconds=0.0625, ref=True)
         # It's important to have a timeout for the select loop, because


### PR DESCRIPTION
This gevent.sleep statement in websocketd.py is effectively limiting websockets to 16 metrics/second.  The new sesnors installed at Tidmarsh yesterday seem to have pushed us over this limit and the websocket is now lagging over an hour behind realtime.

The sleep shouldn't be necessary at all, as the select should yield from the greenlet if there's no data on any ZMQ socket.