### PR TITLE
Revert "remove sleep that unnecessarily ratelimits websocket data"

### DIFF
--- a/chain/websocketd.py
+++ b/chain/websocketd.py
@@ -79,6 +79,7 @@ def close_socket(zmq_sock):
 def select_zmq_socks():
     logger.info("Starting select loop over ZMQ sockets")
     while True:
+        gevent.sleep(seconds=0.0625, ref=True)
         while len(zmq_socks) == 0:
             gevent.sleep(seconds=0.0625, ref=True)
         # It's important to have a timeout for the select loop, because


### PR DESCRIPTION
Reverts ResEnv/chain-api#92

Looks like that `sleep` is necessary after all. stay tuned for a commit to use `gevent.idle()` instead, which will have the same yielding behavior but will only sleep for one event loop pass.